### PR TITLE
Fix typo for SSH key path

### DIFF
--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -1,3 +1,3 @@
 ssh:
-  pub_key_path: "~/.ssh/id_dsa.pub"
+  pub_key_path: "~/.ssh/id_rsa.pub"
 timezone: "Etc/UTC"


### PR DESCRIPTION
When running the basic setup with 
```
ansible-playbook -k -i hosts setup.yml
```
... Ansible throws this error without this fix:
```
FAILED! => {"changed": false, "failed": true, "msg": "could not find src=/home/mac/.ssh/id_dsa.pub"}
```
This PR fixes the error.