### PR TITLE
Fix invalid path /invalid ansible syntax

### DIFF
--- a/includes/install_binaries.yml
+++ b/includes/install_binaries.yml
@@ -13,4 +13,4 @@
 
 - name: Install Binaries
   copy: src=bin/{{ item }} dest=/usr/bin/{{ item }} owner=root group=root mode=0755
-  with_items: binaries.commands
+  with_items: "{{ binaries.commands }}"


### PR DESCRIPTION
` ansible-playbook -i hosts kubernetes.yml`
does not work without this.