### PR TITLE
Configure docker to always use overlay2 as storage driver

### DIFF
--- a/roles/base/tasks/apt.yml
+++ b/roles/base/tasks/apt.yml
@@ -37,6 +37,12 @@
     autoremove: yes
     force: yes
 
+- name: Set overlay driver for docker
+  lineinfile:
+    dest: /lib/systemd/system/docker.service
+    regexp: '^ExecStart='
+    line: 'ExecStart=/usr/bin/dockerd -H fd:// -s overlay2'
+
 - name: Install Packages
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
This should fix #15 by ensuring that the storage driver is always overlay2